### PR TITLE
SCAL-192741 added enum to support custom style config and color pallete

### DIFF
--- a/src/types/common.types.ts
+++ b/src/types/common.types.ts
@@ -206,7 +206,7 @@ export type CustomFontFaces = {
 
 /**
  * Used for Custom color pallete and Custom font for charts defined in Style customisations
- * inside thoughtspot admin section
+ * inside thoughtspot admin or developer section
  *
  */
 

--- a/src/types/common.types.ts
+++ b/src/types/common.types.ts
@@ -191,7 +191,7 @@ export type VisualProps = JSON;
  */
 
 export type CustomFontFaces = {
-    id?: string;
+    guid?: string;
     family?: string;
     format?: string;
     url?: string;

--- a/src/types/common.types.ts
+++ b/src/types/common.types.ts
@@ -11,6 +11,28 @@ import { ChartConfigEditorDefinition } from './configurator.types';
 import { VisualPropEditorDefinition } from './visual-prop.types';
 
 /**
+ * Defines types of features for which font can be customised with Custom style config used in TS.
+ * @remarks
+ * Use chartFeatureToFontGuid to get the guid for the feature and get the font face from guid
+ * from customFontFaces
+ */
+
+export enum CustomizableChartFeature {
+    X_AXIS_LABEL,
+    X_AXIS_TITLE,
+    Y_AXIS_LABEL,
+    Y_AXIS_TITLE,
+    TOOLTIP,
+    SCATTER_CHART,
+    PIE_CHART,
+    LINE_CHART,
+    COLUMN_CHART,
+    BAR_CHART,
+    AREA_CHART,
+    TAIL_FEATURE,
+}
+
+/**
  * List of Columns for a dimension in the Custom Chart Config.
  * Associated with the key defined in the chart config editor definition
  * Relates to ChartConfigSection
@@ -164,14 +186,45 @@ export type ValidationResponse = {
  */
 export type VisualProps = JSON;
 
-// Todo: this should be imported from the custom style config package.
-type CustomStylingConfig = any;
+/**
+ * Custom Font Faces type from TS.
+ */
+
+export type CustomFontFaces = {
+    id?: string;
+    family?: string;
+    format?: string;
+    url?: string;
+    weight?: string;
+    style?: string;
+    size?: string;
+    unicodeRange?: string;
+    variant?: string;
+    stretch?: string;
+    color?: string;
+};
+
+/**
+ * Used for Custom color pallete and Custom font for charts defined in Style customisations
+ * inside thoughtspot admin section
+ *
+ */
+
+export type ChartSdkCustomStylingConfig = {
+    appBackground?: {
+        color?: string;
+    };
+    appPanelColor?: {
+        color?: string;
+    };
+    chartColorPalettes?: Array<{ colors: Array<string> }>;
+    disableColorRotation?: boolean;
+    chartFeatureToFontGuid: Record<CustomizableChartFeature, string>;
+    customFontFaces?: Array<CustomFontFaces>;
+};
 
 export interface AppConfig {
-    /**
-     * @hidden
-     */
-    styleConfig?: CustomStylingConfig;
+    styleConfig?: ChartSdkCustomStylingConfig;
 
     appOptions?: {
         isMobile?: boolean;

--- a/src/types/common.types.ts
+++ b/src/types/common.types.ts
@@ -191,7 +191,7 @@ export type VisualProps = JSON;
  */
 
 export type CustomFontFaces = {
-    guid?: string;
+    guid: string;
     family?: string;
     format?: string;
     url?: string;
@@ -219,7 +219,7 @@ export type ChartSdkCustomStylingConfig = {
     };
     chartColorPalettes?: Array<{ colors: Array<string> }>;
     disableColorRotation?: boolean;
-    chartFeatureToFontGuid: Record<CustomizableChartFeature, string>;
+    chartFeatureToFontGuid?: Record<CustomizableChartFeature, string>;
     customFontFaces?: Array<CustomFontFaces>;
 };
 


### PR DESCRIPTION
## Summary
Added styleConfig type for custom style config

## Changes
<!-- List the key changes in this PR -->
- Added CustomizableChartFeature Enum
- Added custom color pallete and other configs available in admin panel

## Why It Is Needed
<!-- Explain why these changes are necessary -->
Currently we are not passing app level style config for charts to ts-chart-sdk. Supported changes will be done in ts-chart-app to pass the correct values based on type specified for styleConfig

## Testing
<!-- Briefly describe the testing you have done -->
- Should be tested as part of current UTs
- Manual testing done.

