### PR TITLE
SCAL-220287 SDK Upgrade cause event updates to fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@thoughtspot/ts-chart-sdk",
     "private": false,
-    "version": "0.0.2-alpha.10",
+    "version": "0.0.2-alpha.11",
     "module": "lib/index",
     "main": "lib/index",
     "types": "lib/index",

--- a/src/main/custom-chart-context.ts
+++ b/src/main/custom-chart-context.ts
@@ -572,7 +572,7 @@ export class CustomChartContext {
         const messageResponse = this.executeEventListenerCBs(data);
 
         // respond back to parent to confirm/ack the receipt
-        return messageResponse;
+        return messageResponse || {};
     };
 
     /**


### PR DESCRIPTION
After  PDOM changes, the response message was being sent as undefined, which caused the TypeError. As a result, the isInitialise was never being set to true, preventing the changes from being reflected.