### PR TITLE
[SCAL-261243] Add dataSourceName to ChartColumn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@thoughtspot/ts-chart-sdk",
-    "version": "2.14.0",
+    "version": "2.14.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@thoughtspot/ts-chart-sdk",
-            "version": "2.14.0",
+            "version": "2.14.1",
             "license": "ThoughtSpot Development Tools End User License Agreement",
             "dependencies": {
                 "cldr-data": "^36.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@thoughtspot/ts-chart-sdk",
     "private": false,
-    "version": "2.14.0",
+    "version": "2.14.1",
     "module": "lib/index",
     "main": "lib/index",
     "types": "lib/index",

--- a/src/types/answer-column.types.ts
+++ b/src/types/answer-column.types.ts
@@ -340,4 +340,26 @@ export interface ChartColumn {
      * @version SDK: 2.11.3 | ThoughtSpot:
      */
     formulaId?: string;
+
+    /**
+     * Display name of the data source (table / worksheet / model) that backs
+     * this column. Resolved by the host, so it is already localized and
+     * accounts for the special cases below.
+     *
+     * 1. For a column referencing exactly one table, this is that table's
+     *    display name.
+     * 2. For an in-answer formula or a filter-only column, this is the
+     *    localized "Formula" label.
+     * 3. For a column referencing multiple tables, this falls back to the
+     *    column's base name.
+     *
+     * Charts use this to show the column's origin — for example in the axis
+     * tooltip alongside the column name and {@link aggregationType}.
+     *
+     * @example
+     * "Parameters Model"
+     *
+     * @version SDK: 2.14.1 | ThoughtSpot:
+     */
+    dataSourceName?: string;
 }


### PR DESCRIPTION
## Summary

Adds an optional `dataSourceName` to `ChartColumn` so charts can tell which
table / worksheet / model a column comes from.

This unblocks showing the data source in the axis tooltip for Valkyrie
charts, matching what TS native charts already do:

> Name: Total Tax
> Aggregation: Total
> Data source: Parameters Model

`ChartColumn` already carries `aggregationType`, so the aggregation row was
already possible. The data source row was not — nothing in `ChartModel` or
`AppConfig` carried table information. (`AppConfig.dateFormatsConfig.defaultDataSourceId`
is a custom-calendar GUID, not a per-column source name.)

## Changes

- Add optional `dataSourceName?: string` to `ChartColumn` in
  `src/types/answer-column.types.ts`
- Bump version `2.14.0` -> `2.14.1`

